### PR TITLE
Fix typo in github oauth

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,10 +13,10 @@ export default function createApp() {
 
     // setup mongoose
     // @ts-ignore
-    const mongoUrl = process.env.DB_URL + process.env.DB_NAME;
-    connect(mongoUrl, {
+    connect(process.env.DB_URL || '', {
         user: process.env.DB_USERNAME,
         pass: process.env.DB_PASSWORD,
+        dbName: process.env.DB_NAME,
         useNewUrlParser: true,
         useCreateIndex: true,
         useUnifiedTopology: true

--- a/server/src/libs/strategies.ts
+++ b/server/src/libs/strategies.ts
@@ -156,7 +156,7 @@ const githubStrategy = new GithubStrategy(
         // if it isn't registered create new account
         user = new User({
             email,
-            gitubId: profile.id,
+            githubId: profile.id,
             profile: {
                 name: profile.displayName,
                 picture: profile._json.avatar_url


### PR DESCRIPTION
The error was caused by a typo in the GitHub strategy. I spelled `githubId` as `gitubId`